### PR TITLE
ENH: Support temporary image material

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,14 +21,21 @@ install:
   - conda config --add channels pandas
   - conda update -q conda
   - conda info -a
-  - conda create -q -n test-environment python=$PYTHON pip numpy nose
+  - conda create -q -n test-environment python=$PYTHON pip nose
   - source activate test-environment
   - if [[ "$SHAPELY" == "true" ]]; then
-      conda install numpy scipy shapely;
+      conda install numpy scipy shapely matplotlib;
     fi
   - python setup.py install
+
+before_script:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3 # give xvfb some time to start
+
 script:
   - nosetests --with-coverage
+
 after_success:
   - coveralls
 

--- a/cesiumpy/entities/material.py
+++ b/cesiumpy/entities/material.py
@@ -3,7 +3,9 @@
 
 from __future__ import unicode_literals
 
+import os
 import six
+import tempfile
 import traitlets
 
 from cesiumpy.base import _CesiumObject
@@ -62,3 +64,43 @@ class ImageMaterialProperty(Material):
         props = super(ImageMaterialProperty, self).script
         return 'new Cesium.{klass}({props})'.format(klass=self.__class__.__name__,
                                                     props=props)
+
+
+class TemporaryImageMaterialProperty(ImageMaterialProperty):
+    """
+    ImageMaterialProperty which can handle temporary image.
+    Temporary image is output on the current working directory, and will be
+    deleted when the instance is deleted.
+
+    Parameters
+    ----------
+
+    figure: matplotlib.figure
+        A matplotlib figure saved as temporary image
+    repeat: Cartesian2, default new Cartesian2(1.0, 1.0)
+        A Cartesian2 Property specifying the number of times
+    """
+
+    def __init__(self, figure, repeat=None):
+        # using absolute path of tempfile doesn't work,
+        # thus can't use NamedTemporaryFile
+        _, tmp = tempfile.mkstemp(dir='.', suffix='.png')
+        # store full path
+        self.tempfile = tmp
+        figure.savefig(self.tempfile, format="png", transparent=True)
+
+        image = os.path.basename(tmp)
+        super(TemporaryImageMaterialProperty, self).__init__(image, repeat=repeat)
+
+        self.image = image
+        com._check_uri(self.image)
+
+    @property
+    def script(self):
+        props = super(ImageMaterialProperty, self).script
+        return 'new Cesium.ImageMaterialProperty({props})'.format(props=props)
+
+    def __del__(self):
+        if os.path.exists(self.tempfile):
+            os.remove(self.tempfile)
+

--- a/cesiumpy/entities/tests/test_material.py
+++ b/cesiumpy/entities/tests/test_material.py
@@ -4,9 +4,11 @@
 import nose
 import unittest
 
+import re
 import traitlets
 
 import cesiumpy
+import cesiumpy.testing as tm
 
 
 class TestImageMaterial(unittest.TestCase):
@@ -15,6 +17,20 @@ class TestImageMaterial(unittest.TestCase):
         m = cesiumpy.entities.material.ImageMaterialProperty('xxx.png')
         self.assertEqual(repr(m), 'ImageMaterialProperty(xxx.png)')
         self.assertEqual(m.script, """new Cesium.ImageMaterialProperty({image : "xxx.png"})""")
+
+
+class TestTempImageMaterial(unittest.TestCase):
+
+    def test_matplotlibimage(self):
+        tm._skip_if_no_matplotlib()
+
+        import numpy as np
+        import matplotlib.pyplot as plt
+
+        img = np.random.randint(0, 255, (100, 100, 3))
+        ax = plt.imshow(img)
+        m = cesiumpy.entities.material.TemporaryImageMaterialProperty(ax.figure)
+        self.assertTrue(re.match("""new Cesium\\.ImageMaterialProperty\\({image : "\w+\\.png"}\\)""", m.script))
 
 
 if __name__ == '__main__':

--- a/cesiumpy/testing.py
+++ b/cesiumpy/testing.py
@@ -18,3 +18,13 @@ def _skip_if_no_shapely():
     except ImportError:
         import nose
         raise nose.SkipTest("no shapely.geometry module")
+
+
+def _skip_if_no_matplotlib():
+    try:
+        import matplotlib
+        matplotlib.use('Agg')
+        import matplotlib.pyplot
+    except ImportError:
+        import nose
+        raise nose.SkipTest("no matplotlib.pyplot module")


### PR DESCRIPTION
```

x, y, s = np.random.random_integers(0, 200, (3, 100))
ax = plt.scatter(x, y, s=s)
ax
```

![index](https://cloud.githubusercontent.com/assets/1696302/12376618/7d6ad246-bd41-11e5-9480-18d004eeb8a3.png)


```
imp = cesiumpy.entities.material.TemporaryImageMaterialProperty(ax.figure)
v = cesiumpy.Viewer()
e = cesiumpy.Rectangle(coordinates=(-120.0, 40.0, -100, 60), material=imp)
v.entities.add(e)
v
```

![2016-01-17 17 38 00](https://cloud.githubusercontent.com/assets/1696302/12376619/81f04940-bd41-11e5-9b05-7b73b0370bef.png)
