### PR TITLE
CLN: made tempfile class

### DIFF
--- a/cesiumpy/entities/tests/test_material.py
+++ b/cesiumpy/entities/tests/test_material.py
@@ -29,9 +29,21 @@ class TestTempImageMaterial(unittest.TestCase):
 
         img = np.random.randint(0, 255, (100, 100, 3))
         ax = plt.imshow(img)
-        m = cesiumpy.entities.material.TemporaryImageMaterialProperty(ax.figure)
+        img = cesiumpy.entities.material.TemporaryImage(ax.figure)
+        m = cesiumpy.entities.material.ImageMaterialProperty(img)
         self.assertTrue(re.match("""new Cesium\\.ImageMaterialProperty\\({image : "\w+\\.png"}\\)""", m.script))
 
+        img = cesiumpy.entities.material.TemporaryImage(ax)
+        m = cesiumpy.entities.material.ImageMaterialProperty(img)
+        self.assertTrue(re.match("""new Cesium\\.ImageMaterialProperty\\({image : "\w+\\.png"}\\)""", m.script))
+        plt.close()
+
+        fig, axes = plt.subplots(2, 2)
+        msg = "Unable to trim a Figure contains multiple Axes"
+        with nose.tools.assert_raises_regexp(ValueError, msg):
+            img = cesiumpy.entities.material.TemporaryImage(fig)
+            cesiumpy.entities.material.ImageMaterialProperty(img)
+        plt.close()
 
 if __name__ == '__main__':
     import nose

--- a/cesiumpy/provider.py
+++ b/cesiumpy/provider.py
@@ -478,6 +478,10 @@ class SingleTileImageryProvider(ImageryProvider):
 
     def __init__(self, url, rectangle=None, ellipsoid=None, credit=None, proxy=None):
 
+        from cesiumpy.entities.material import TemporaryImage
+        if isinstance(url, TemporaryImage):
+            url = url.script
+
         super(SingleTileImageryProvider, self).__init__(url=url, rectangle=rectangle,
                                                         ellipsoid=ellipsoid,
                                                         credit=credit, proxy=proxy)

--- a/cesiumpy/tests/test_provider.py
+++ b/cesiumpy/tests/test_provider.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python
 # coding: utf-8
 
-import unittest
 import nose
+import unittest
+
+import re
 import traitlets
 
 import cesiumpy
-
+import cesiumpy.testing as tm
 
 
 class TestTerrainProvider(unittest.TestCase):
@@ -189,6 +191,19 @@ class TestImageProvider(unittest.TestCase):
         result = imageryProvider.script
         exp = """new Cesium.SingleTileImageryProvider({url : "../images/Cesium_Logo_overlay.png", rectangle : Cesium.Rectangle.fromDegrees(-115.0, 38.0, -107.0, 39.75)})"""
         self.assertEqual(result, exp)
+
+    def test_SingleTimeImageryProvider_tempfile(self):
+        tm._skip_if_no_matplotlib()
+
+        import numpy as np
+        import matplotlib.pyplot as plt
+
+        img = np.random.randint(0, 255, (100, 100, 3))
+        ax = plt.imshow(img)
+        img = cesiumpy.entities.material.TemporaryImage(ax.figure)
+        m = cesiumpy.SingleTileImageryProvider(img, rectangle=(-120.0, 40.0, -100, 60))
+        self.assertTrue(re.match("""new Cesium\\.SingleTileImageryProvider\\(\\{url : "\w+\\.png", rectangle : Cesium\\.Rectangle\\.fromDegrees\\(-120\\.0, 40\\.0, -100\\.0, 60\\.0\\)\\}\\)""", m.script))
+        plt.close()
 
     def test_BingMapsImageryProvider(self):
         """


### PR DESCRIPTION
Follow-up of #29. Remove ``TemporaryImageMaterialProperty``, and add ``TemporaryImage`` class which can be directly passed to ``ImageMaterialProperty``.

```
img = cesiumpy.entities.material.TemporaryImage(ax.figure)
imp = cesiumpy.entities.material.ImageMaterialProperty(image=img)
imp.script
# u'new Cesium.ImageMaterialProperty({image : "tmpo1RvRH.png"})'
```