### PR TITLE
Lazily instantiate geocoder

### DIFF
--- a/cesiumpy/extension/geocode.py
+++ b/cesiumpy/extension/geocode.py
@@ -8,8 +8,15 @@ from geopy.geocoders import GoogleV3
 
 import cesiumpy.util.common as com
 
-# ToDo: want different geocoders?
-_GEOCODER = GoogleV3()
+_GEOCODER = None
+
+
+def _get_geocoder():
+    global _GEOCODER
+    if _GEOCODER is None:
+        # ToDo: want different geocoders?
+        _GEOCODER = GoogleV3()
+    return _GEOCODER
 
 
 def _maybe_geocode(x, height=None):
@@ -18,7 +25,7 @@ def _maybe_geocode(x, height=None):
     height can be used to create base data for Cartesian3
     """
     if isinstance(x, six.string_types):
-        loc = _GEOCODER.geocode(x)
+        loc = _get_geocoder().geocode(x)
         if loc is not None:
             if height is None:
                 # return x, y order


### PR DESCRIPTION
Currently, importing `cesiumpy` with geopy v2.0.0 or greater errors out. This is due to [this](https://github.com/geopy/geopy/commit/340999453ff6e28b2943544b92162858a1560d8d) change in v2.1.0 requiring an API key for geocoding.

This PR lazily loads the geocoder to prevent the immediate exception with geopy versions > 2.0.0.

Closes https://github.com/sinhrks/cesiumpy/issues/77. Related to https://github.com/sinhrks/cesiumpy/pull/79.